### PR TITLE
[BUGFIX] Use proper language file in flexform

### DIFF
--- a/Configuration/FlexForms/flexform_ds.xml
+++ b/Configuration/FlexForms/flexform_ds.xml
@@ -77,7 +77,7 @@
 					<pages>
 						<TCEforms>
 							<exclude>1</exclude>
-							<label>LLL:EXT:lang/locallang_general.php:LGL.startingpoint</label>
+							<label>LLL:EXT:lang/locallang_general.xlf:LGL.startingpoint</label>
 							<config>
 								<type>group</type>
 								<internal_type>db</internal_type>
@@ -91,7 +91,7 @@
 					</pages>
 					<recursive>
 						<TCEforms>
-							<label>LLL:EXT:lang/locallang_general.php:LGL.recursive</label>
+							<label>LLL:EXT:lang/locallang_general.xlf:LGL.recursive</label>
 							<config>
 								<type>select</type>
 								<items type="array">


### PR DESCRIPTION
Use proper path to locallang_general file