### PR TITLE
TYPO3 8.7 TCA compatibility fixes

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -5,7 +5,7 @@ if (is_array($GLOBALS['TCA']['pages']['ctrl']['typeicon_classes'])) {
 }
 
 // Adding sysfolder icon
-$GLOBALS['TCA']['pages']['columns']['module']['config']['items'][$_EXTKEY]['0']
+$GLOBALS['TCA']['pages']['columns']['module']['config']['items']['irfaq']['0']
         = 'LLL:EXT:irfaq/Resources/Private/Language/locallang_db.xlf:tx_irfaq.sysfolder';
-$GLOBALS['TCA']['pages']['columns']['module']['config']['items'][$_EXTKEY]['1'] = $_EXTKEY;
+$GLOBALS['TCA']['pages']['columns']['module']['config']['items']['irfaq']['1'] = 'irfaq';
 

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -3,3 +3,9 @@
 if (is_array($GLOBALS['TCA']['pages']['ctrl']['typeicon_classes'])) {
     $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-irfaq'] = 'tcarecords-pages-contains-irfaq';
 }
+
+// Adding sysfolder icon
+$GLOBALS['TCA']['pages']['columns']['module']['config']['items'][$_EXTKEY]['0']
+        = 'LLL:EXT:irfaq/Resources/Private/Language/locallang_db.xlf:tx_irfaq.sysfolder';
+$GLOBALS['TCA']['pages']['columns']['module']['config']['items'][$_EXTKEY]['1'] = $_EXTKEY;
+

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -4,7 +4,7 @@ if (!defined('TYPO3_MODE')) {
 }
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-    $_EXTKEY,
+    'irfaq',
     'Configuration/TypoScript/',
     'IRFAQ default TS'
 );

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,11 @@
+<?php
+if (!defined('TYPO3_MODE')) {
+    die ('Access denied.');
+}
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    $_EXTKEY,
+    'Configuration/TypoScript/',
+    'IRFAQ default TS'
+);
+

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,18 @@
+<?php
+if (!defined('TYPO3_MODE')) {
+    die ('Access denied.');
+}
+
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['irfaq_pi1'] = 'layout,select_key,pages';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['irfaq_pi1'] = 'pi_flexform';
+
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
+    ['LLL:EXT:irfaq/Resources/Private/Language/locallang_db.xlf:tt_content.list_type_pi1', 'irfaq_pi1'],
+    'list_type',
+    'irfaq'
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    'irfaq_pi1',
+    'FILE:EXT:irfaq/Configuration/FlexForms/flexform_ds.xml'
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,47 +11,15 @@ if (!defined('TYPO3_MODE')) {
 
 
 
-$TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY . '_pi1'] = 'layout,select_key,pages';
-$TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY . '_pi1'] = 'pi_flexform';
+$GLOBALS['TBE_MODULES_EXT']['xMOD_db_new_content_el']['addElClasses']['Netcreators\\Irfaq\\System\\Backend\\WizardIcon'] =
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('irfaq')
+        . 'Classes/System/Backend/WizardIcon.php';
 
-
-
-// Adding sysfolder icon
-$TCA['pages']['columns']['module']['config']['items'][$_EXTKEY]['0']
-    = 'LLL:EXT:irfaq/Resources/Private/Language/locallang_db.xlf:tx_irfaq.sysfolder';
-$TCA['pages']['columns']['module']['config']['items'][$_EXTKEY]['1'] = $_EXTKEY;
-
-
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-    $_EXTKEY,
-    'Configuration/TypoScript/',
-    'IRFAQ default TS'
+/** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
+$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+$iconRegistry->registerIcon(
+    'tcarecords-pages-contains-irfaq',
+    \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
+    ['source' => 'EXT:irfaq/Resources/Public/Icons/icon_tx_irfaq_sysfolder.gif']
 );
 
-
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
-    ['LLL:EXT:irfaq/Resources/Private/Language/locallang_db.xlf:tt_content.list_type_pi1', $_EXTKEY . '_pi1'],
-    'list_type'
-);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-    $_EXTKEY . '_pi1',
-    'FILE:EXT:irfaq/Configuration/FlexForms/flexform_ds.xml'
-);
-
-
-
-if (TYPO3_MODE == 'BE') {
-    $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['Netcreators\\Irfaq\\System\\Backend\\WizardIcon'] =
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('irfaq')
-            . 'Classes/System/Backend/WizardIcon.php';
-
-    /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
-    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-    $iconRegistry->registerIcon(
-        'tcarecords-pages-contains-irfaq',
-        \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
-        ['source' => 'EXT:irfaq/Resources/Public/Icons/icon_tx_irfaq_sysfolder.gif']
-    );
-}


### PR DESCRIPTION
Hello,
I moved TCA from ext_tables to Configuration/TCA/Overrides where it should be in TYPO3 8.7 because it shows messages in install tool.